### PR TITLE
tests: Add e2e tests for AKS

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@v5
         with:
-          # Configure which types are allowed (default: feat, fix, docs, style, refactor, test, chore)
           types: |
             feat
             fix
@@ -32,6 +31,7 @@ jobs:
             perf
             test
             build
+            build(deps)
             ci
             chore
           # Configure which scopes are allowed (optional)

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -54,7 +54,6 @@ Here are some key points about machine learning:
 ....
 
 >/quit
-👋 Goodbye!
 ```
 
 ### Configure Inference Parameters

--- a/hack/test/e2e/cleanup-aks.sh
+++ b/hack/test/e2e/cleanup-aks.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Kaito Project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# cleanup-aks.sh - Cleanup AKS cluster after e2e tests
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_INFO_FILE="${SCRIPT_DIR}/aks-cluster-info.env"
+
+echo -e "${BLUE}🧹 Cleaning up AKS cluster and resources${NC}"
+
+# Check if Azure CLI is available
+if ! command -v az >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  Azure CLI not found, cannot clean up AKS resources${NC}"
+    exit 1
+fi
+
+# Check if authenticated
+if ! az account show >/dev/null 2>&1; then
+    echo -e "${RED}❌ Not authenticated with Azure. Please run 'az login' first.${NC}"
+    exit 1
+fi
+
+# Load cluster info if available
+if [ -f "${CLUSTER_INFO_FILE}" ]; then
+    echo -e "${BLUE}📋 Loading cluster info from ${CLUSTER_INFO_FILE}${NC}"
+    source "${CLUSTER_INFO_FILE}"
+else
+    echo -e "${YELLOW}⚠️  Cluster info file not found. Using environment variables or defaults.${NC}"
+fi
+
+# Use environment variables or prompt for values
+if [ -z "$AKS_RESOURCE_GROUP" ]; then
+    echo -e "${YELLOW}🔍 AKS_RESOURCE_GROUP not set. Please provide the resource group name:${NC}"
+    read -p "Resource Group: " AKS_RESOURCE_GROUP
+fi
+
+if [ -z "$AKS_CLUSTER_NAME" ]; then
+    echo -e "${YELLOW}🔍 AKS_CLUSTER_NAME not set. Please provide the cluster name:${NC}"
+    read -p "Cluster Name: " AKS_CLUSTER_NAME
+fi
+
+if [ -z "$AKS_RESOURCE_GROUP" ] || [ -z "$AKS_CLUSTER_NAME" ]; then
+    echo -e "${RED}❌ Missing required information. Cannot proceed with cleanup.${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}📋 Cleanup configuration:${NC}"
+echo -e "   Resource Group: ${AKS_RESOURCE_GROUP}"
+echo -e "   Cluster Name: ${AKS_CLUSTER_NAME}"
+
+# Get confirmation unless in CI
+if [ -z "$CI" ] && [ -z "$SKIP_CONFIRMATION" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  This will delete the entire resource group and all resources within it!${NC}"
+    echo -n "Are you sure you want to proceed? (y/N): "
+    read -r response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+fi
+
+# Check if resource group exists
+if ! az group show --name "${AKS_RESOURCE_GROUP}" >/dev/null 2>&1; then
+    echo -e "${GREEN}✅ Resource group ${AKS_RESOURCE_GROUP} does not exist, nothing to clean up${NC}"
+    rm -f "${CLUSTER_INFO_FILE}"
+    exit 0
+fi
+
+# Delete the resource group (this deletes the cluster and all associated resources)
+echo -e "${YELLOW}🗑️  Deleting resource group: ${AKS_RESOURCE_GROUP}${NC}"
+echo -e "${BLUE}   This will delete the AKS cluster and all associated resources...${NC}"
+
+az group delete --name "${AKS_RESOURCE_GROUP}" --yes --no-wait
+
+echo -e "${GREEN}✅ AKS cluster deletion initiated${NC}"
+echo -e "${BLUE}💡 Deletion is running in the background and may take several minutes to complete.${NC}"
+echo -e "${BLUE}   You can check the status in the Azure portal or with:${NC}"
+echo -e "${BLUE}   az group show --name ${AKS_RESOURCE_GROUP}${NC}"
+
+# Clean up cluster info file
+if [ -f "${CLUSTER_INFO_FILE}" ]; then
+    rm -f "${CLUSTER_INFO_FILE}"
+    echo -e "${BLUE}🗑️  Removed cluster info file${NC}"
+fi
+
+echo -e "${GREEN}✅ AKS cluster cleanup complete!${NC}" 

--- a/hack/test/e2e/setup-aks.sh
+++ b/hack/test/e2e/setup-aks.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Kaito Project
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# setup-aks.sh - Setup AKS cluster and prerequisites for e2e tests
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Default values - can be overridden by environment variables
+AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME:-kaito-e2e-aks-$(date +%s)}"
+AKS_RESOURCE_GROUP="${AKS_RESOURCE_GROUP:-kaito-e2e-rg-$(date +%s)}"
+AKS_LOCATION="${AKS_LOCATION:-eastus}"
+AKS_NODE_VM_SIZE="${AKS_NODE_VM_SIZE:-Standard_NC6s_v3}"
+AKS_NODE_COUNT="${AKS_NODE_COUNT:-1}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.33.0}"
+
+TIMEOUT_CLUSTER=20m
+TIMEOUT_INSTALL=5m
+
+echo -e "${BLUE}🚀 Setting up AKS cluster and prerequisites for e2e tests${NC}"
+echo -e "${YELLOW}⚠️  Warning: This will create billable Azure resources!${NC}"
+echo -e "${YELLOW}   Estimated cost: $2-5 for a 1-hour test run${NC}"
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to install kubectl
+install_kubectl() {
+    echo -e "${YELLOW}📦 Installing kubectl...${NC}"
+    
+    if command_exists brew; then
+        brew install kubectl
+    elif command_exists curl; then
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/
+    else
+        echo -e "${RED}❌ Unable to install kubectl: no suitable package manager found${NC}"
+        exit 1
+    fi
+}
+
+# Function to install Azure CLI
+install_azure_cli() {
+    echo -e "${YELLOW}📦 Installing Azure CLI...${NC}"
+    
+    if command_exists brew; then
+        brew install azure-cli
+    elif command_exists apt-get; then
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    elif command_exists yum; then
+        sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+        echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/azure-cli.repo
+        sudo yum install azure-cli
+    elif command_exists curl; then
+        curl -L https://aka.ms/InstallAzureCli | bash
+    else
+        echo -e "${RED}❌ Unable to install Azure CLI: no suitable package manager found${NC}"
+        exit 1
+    fi
+}
+
+# Check and install prerequisites
+echo -e "${BLUE}🔍 Checking prerequisites...${NC}"
+
+# Check kubectl
+if ! command_exists kubectl; then
+    install_kubectl
+else
+    echo -e "${GREEN}✅ kubectl is available${NC}"
+fi
+
+# Check helm
+if ! command_exists helm; then
+    install_helm
+else
+    echo -e "${GREEN}✅ helm is available${NC}"
+fi
+
+# Check Azure CLI
+if ! command_exists az; then
+    install_azure_cli
+else
+    echo -e "${GREEN}✅ Azure CLI is available${NC}"
+fi
+
+# Check Azure authentication
+echo -e "${BLUE}🔐 Checking Azure authentication...${NC}"
+if ! az account show >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  Not logged into Azure${NC}"
+    echo -e "${BLUE}🔑 Please log into Azure:${NC}"
+    az login
+    
+    if ! az account show >/dev/null 2>&1; then
+        echo -e "${RED}❌ Azure authentication failed${NC}"
+        exit 1
+    fi
+fi
+
+echo -e "${GREEN}✅ Azure CLI is authenticated${NC}"
+az account show --output table
+
+# Get confirmation unless in CI
+if [ -z "$CI" ] && [ -z "$SKIP_CONFIRMATION" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  About to create AKS cluster with the following configuration:${NC}"
+    echo -e "   Cluster Name: ${AKS_CLUSTER_NAME}"
+    echo -e "   Resource Group: ${AKS_RESOURCE_GROUP}"
+    echo -e "   Location: ${AKS_LOCATION}"
+    echo -e "   VM Size: ${AKS_NODE_VM_SIZE}"
+    echo -e "   Node Count: ${AKS_NODE_COUNT}"
+    echo ""
+    echo -n "Do you want to proceed? (y/N): "
+    read -r response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+fi
+
+# Clean up any existing resources
+echo -e "${BLUE}🧹 Cleaning up any existing resources...${NC}"
+if az group show --name "${AKS_RESOURCE_GROUP}" >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  Deleting existing resource group: ${AKS_RESOURCE_GROUP}${NC}"
+    az group delete --name "${AKS_RESOURCE_GROUP}" --yes --no-wait
+    echo -e "${BLUE}⏳ Waiting for resource group deletion to complete...${NC}"
+    while az group show --name "${AKS_RESOURCE_GROUP}" >/dev/null 2>&1; do
+        sleep 30
+        echo -e "${BLUE}   Still waiting for deletion...${NC}"
+    done
+fi
+
+# Create resource group
+echo -e "${BLUE}🏗️  Creating resource group: ${AKS_RESOURCE_GROUP}${NC}"
+az group create --name "${AKS_RESOURCE_GROUP}" --location "${AKS_LOCATION}"
+
+# Create AKS cluster
+echo -e "${BLUE}🏗️  Creating AKS cluster: ${AKS_CLUSTER_NAME}${NC}"
+echo -e "${YELLOW}   This may take 10-15 minutes...${NC}"
+
+timeout "${TIMEOUT_CLUSTER}" az aks create \
+    --resource-group "${AKS_RESOURCE_GROUP}" \
+    --name "${AKS_CLUSTER_NAME}" \
+    --node-count "${AKS_NODE_COUNT}" \
+    --node-vm-size "${AKS_NODE_VM_SIZE}" \
+    --generate-ssh-keys \
+    --enable-oidc-issuer \
+    --enable-ai-toolchain-operator \
+    --kubernetes-version "${KUBERNETES_VERSION}"
+
+# Get credentials
+echo -e "${BLUE}🔑 Getting AKS credentials...${NC}"
+az aks get-credentials \
+    --resource-group "${AKS_RESOURCE_GROUP}" \
+    --name "${AKS_CLUSTER_NAME}" \
+    --overwrite-existing
+
+echo -e "${BLUE}⏳ Waiting for cluster to be ready...${NC}"
+timeout "${TIMEOUT_CLUSTER}" kubectl wait --for=condition=Ready nodes --all --timeout=900s
+
+# Create kaito-system namespace
+kubectl create namespace kaito-system --dry-run=client -o yaml | kubectl apply -f -
+
+echo -e "${GREEN}✅ AKS cluster setup complete!${NC}"
+echo -e "${GREEN}   Cluster: ${AKS_CLUSTER_NAME}${NC}"
+echo -e "${GREEN}   Resource Group: ${AKS_RESOURCE_GROUP}${NC}"
+echo -e "${GREEN}   Location: ${AKS_LOCATION}${NC}"
+echo -e "${GREEN}   Context: ${AKS_CLUSTER_NAME}${NC}"
+
+# Save cluster info for cleanup
+cat > "${SCRIPT_DIR}/aks-cluster-info.env" <<EOF
+AKS_CLUSTER_NAME="${AKS_CLUSTER_NAME}"
+AKS_RESOURCE_GROUP="${AKS_RESOURCE_GROUP}"
+AKS_LOCATION="${AKS_LOCATION}"
+EOF
+
+echo -e "${BLUE}💾 Cluster info saved to: ${SCRIPT_DIR}/aks-cluster-info.env${NC}"
+echo -e "${BLUE}🎯 Ready to run AKS e2e tests!${NC}"
+echo ""
+echo -e "${YELLOW}💡 To clean up after tests, run: ./hack/test/e2e/cleanup-aks.sh${NC}" 

--- a/tests/e2e/aks_test.go
+++ b/tests/e2e/aks_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2024 Kaito Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAKSClusterOperations tests kubectl-kaito plugin functionality on AKS cluster
+func TestAKSClusterOperations(t *testing.T) {
+	t.Run("verify_cluster_ready", func(t *testing.T) {
+		verifyClusterReady(t)
+	})
+
+	t.Run("verify_kaito_operator", func(t *testing.T) {
+		verifyKaitoOperator(t)
+	})
+
+	t.Run("deploy_validation", func(t *testing.T) {
+		testAKSDeployValidation(t)
+	})
+
+	t.Run("status_no_workspaces", func(t *testing.T) {
+		testStatusNoWorkspaces(t)
+	})
+
+	t.Run("get_endpoint_no_workspace", func(t *testing.T) {
+		testGetEndpointNoWorkspace(t)
+	})
+
+	t.Run("models_list", func(t *testing.T) {
+		testModelsList(t)
+	})
+
+	t.Run("models_describe", func(t *testing.T) {
+		testModelsDescribe(t)
+	})
+
+	t.Run("chat_validation", func(t *testing.T) {
+		testChatValidation(t)
+	})
+
+	t.Run("help_commands", func(t *testing.T) {
+		testHelpCommands(t)
+	})
+
+	t.Run("input_validation", func(t *testing.T) {
+		testInputValidation(t)
+	})
+}
+
+// testAKSDeployValidation tests deployment validation on AKS with GPU instance types
+func testAKSDeployValidation(t *testing.T) {
+	stdout, stderr, err := runCommand(t, testTimeout,
+		"deploy",
+		"--workspace-name", "test-gpu-workspace",
+		"--model", "phi-2",
+		"--instance-type", "Standard_NC6s_v3",
+		"--dry-run")
+
+	if err != nil {
+		t.Errorf("Deploy validation failed: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
+		return
+	}
+
+	combinedOutput := stdout + stderr
+	if !strings.Contains(combinedOutput, "Dry-run mode") {
+		t.Errorf("Expected dry-run output not found: %s", combinedOutput)
+	}
+
+	if !strings.Contains(combinedOutput, "Standard_NC6s_v3") {
+		t.Errorf("Expected GPU instance type not found in output: %s", combinedOutput)
+	}
+
+	t.Logf("✅ AKS deploy validation successful")
+}
+
+// testChatValidation tests chat command validation (without actual chat)
+func testChatValidation(t *testing.T) {
+	// Test missing workspace
+	_, _, err := runCommand(t, testTimeout, "chat", "--message", "hello")
+	if err == nil {
+		t.Errorf("Expected error for missing workspace, but command succeeded")
+	}
+	t.Logf("✅ Chat validation correctly requires workspace")
+
+	// Test with workspace but no endpoint (should fail gracefully)
+	_, _, err = runCommand(t, testTimeout,
+		"chat",
+		"--workspace-name", "nonexistent-workspace",
+		"--message", "hello")
+	if err == nil {
+		t.Errorf("Expected error for nonexistent workspace, but command succeeded")
+	}
+	t.Logf("✅ Chat validation correctly handles nonexistent workspace")
+}

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -1,0 +1,301 @@
+/*
+Copyright (c) 2024 Kaito Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	binaryName      = "kubectl-kaito"
+	testTimeout     = 30 * time.Second
+	buildTimeout    = 60 * time.Second
+	longTestTimeout = 120 * time.Second
+)
+
+var (
+	binaryPath string
+)
+
+func runCommand(t *testing.T, timeout time.Duration, args ...string) (string, string, error) {
+	if timeout == 0 {
+		timeout = testTimeout
+	}
+
+	// Check if binary exists
+	if _, err := os.Stat(binaryPath); err != nil {
+		return "", "", fmt.Errorf("binary not found at %s: %v", binaryPath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+}
+
+func runKubectlCommand(t *testing.T, timeout time.Duration, args ...string) (string, error) {
+	if timeout == 0 {
+		timeout = testTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	return strings.TrimSpace(stdout.String()), err
+}
+
+// Common test functions used in the e2e tests
+
+func verifyClusterReady(t *testing.T) {
+	stdout, err := runKubectlCommand(t, testTimeout, "get", "nodes")
+	if err != nil {
+		t.Errorf("Failed to get nodes: %v\nStdout: %s", err, stdout)
+		return
+	}
+
+	if !strings.Contains(stdout, "Ready") {
+		t.Errorf("No Ready nodes found. Output: %s", stdout)
+		return
+	}
+
+	t.Logf("✅ Cluster is ready with nodes: %s", stdout)
+}
+
+func verifyKaitoOperator(t *testing.T) {
+	// Check for Kaito operator in kaito-system namespace first
+	stdout, err := runKubectlCommand(t, longTestTimeout, "get", "deployment", "kaito-controller-manager", "-n", "kaito-system")
+	if err != nil {
+		// If not found in kaito-system, check in kube-system (AKS managed add-on)
+		stdout, err = runKubectlCommand(t, longTestTimeout, "get", "deployment", "-n", "kube-system", "-l", "app=ai-toolchain-operator")
+		if err != nil {
+			// Try checking pods instead
+			stdout, err = runKubectlCommand(t, longTestTimeout, "get", "pods", "-n", "kube-system", "-l", "app=kaito-workspace")
+			if err != nil {
+				t.Errorf("Failed to get Kaito operator: %s\nStderr: %s", err, stdout)
+				return
+			}
+		}
+	}
+
+	if !strings.Contains(stdout, "kaito") {
+		t.Errorf("Kaito operator not found. Output: %s", stdout)
+		return
+	}
+
+	t.Logf("✅ Kaito operator is ready")
+}
+
+func testStatusNoWorkspaces(t *testing.T) {
+	stdout, stderr, err := runCommand(t, testTimeout, "status")
+
+	// Should succeed even with no workspaces
+	combinedOutput := stdout + stderr
+
+	if err != nil {
+		// Check if it's a meaningful error (like CRD not found)
+		if !strings.Contains(combinedOutput, "no resources found") &&
+			!strings.Contains(combinedOutput, "the server doesn't have a resource type") {
+			t.Errorf("Unexpected error: %v\nOutput: %s", err, combinedOutput)
+			return
+		}
+	}
+
+	t.Logf("✅ Status command handles no workspaces correctly")
+}
+
+func testGetEndpointNoWorkspace(t *testing.T) {
+	_, _, err := runCommand(t, testTimeout, "get-endpoint", "--workspace-name", "nonexistent")
+
+	if err == nil {
+		t.Errorf("Expected error for nonexistent workspace, but command succeeded")
+		return
+	}
+
+	t.Logf("✅ Get-endpoint correctly handles nonexistent workspace")
+}
+
+func testModelsList(t *testing.T) {
+	stdout, stderr, err := runCommand(t, longTestTimeout, "models", "list")
+
+	// Should succeed or gracefully handle network failures
+	combinedOutput := stdout + stderr
+
+	if err != nil {
+		// If network fails, should show fallback models
+		if !strings.Contains(combinedOutput, "phi-3.5-mini-instruct") &&
+			!strings.Contains(combinedOutput, "llama-2-7b") {
+			t.Errorf("Expected fallback models not found. Output: %s", combinedOutput)
+			return
+		}
+	} else {
+		// If succeeds, should show model list
+		if !strings.Contains(combinedOutput, "NAME") || !strings.Contains(combinedOutput, "TYPE") {
+			t.Errorf("Expected model list headers not found. Output: %s", combinedOutput)
+			return
+		}
+	}
+
+	t.Logf("✅ Models list successful")
+}
+
+func testModelsDescribe(t *testing.T) {
+	stdout, stderr, err := runCommand(t, testTimeout, "models", "describe", "phi-3.5-mini-instruct")
+
+	combinedOutput := stdout + stderr
+
+	if err != nil {
+		// Should provide helpful error message
+		if !strings.Contains(combinedOutput, "phi-3.5-mini-instruct") {
+			t.Errorf("Expected model name in error message. Output: %s", combinedOutput)
+			return
+		}
+	} else {
+		// If succeeds, should show model details
+		if !strings.Contains(combinedOutput, "phi-3.5-mini-instruct") {
+			t.Errorf("Expected model details not found. Output: %s", combinedOutput)
+			return
+		}
+	}
+
+	t.Logf("✅ Models describe successful")
+}
+
+func testHelpCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"root help", []string{"--help"}},
+		{"models help", []string{"models", "--help"}},
+		{"deploy help", []string{"deploy", "--help"}},
+		{"status help", []string{"status", "--help"}},
+		{"get-endpoint help", []string{"get-endpoint", "--help"}},
+		{"chat help", []string{"chat", "--help"}},
+		// TODO: Uncomment when RAG command is available
+		// {"rag help", []string{"rag", "--help"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, err := runCommand(t, testTimeout, tt.args...)
+
+			// Help should exit with code 0
+			if err != nil {
+				t.Errorf("Help command failed: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
+				return
+			}
+
+			// Should have some help content
+			combinedOutput := stdout + stderr
+			if !strings.Contains(combinedOutput, "Usage:") && !strings.Contains(combinedOutput, "kubectl kaito") {
+				t.Errorf("Expected help content not found in output: %s", combinedOutput)
+				return
+			}
+
+			t.Logf("✅ %s successful", tt.name)
+		})
+	}
+}
+
+func testInputValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name:        "deploy missing workspace name",
+			args:        []string{"deploy", "--model", "llama-2-7b"},
+			expectError: true,
+		},
+		{
+			name:        "deploy missing model",
+			args:        []string{"deploy", "--workspace-name", "test"},
+			expectError: true,
+		},
+		{
+			name:        "deploy invalid model",
+			args:        []string{"deploy", "--workspace-name", "test", "--model", "invalid-model"},
+			expectError: true,
+		},
+		{
+			name:        "chat missing workspace",
+			args:        []string{"chat", "--message", "hello"},
+			expectError: true,
+		},
+		{
+			name:        "get-endpoint missing workspace",
+			args:        []string{"get-endpoint"},
+			expectError: true,
+		},
+		{
+			name:        "rag deploy missing name",
+			args:        []string{"rag", "deploy", "--vector-db", "faiss"},
+			expectError: true,
+		},
+		{
+			name:        "valid dry-run should succeed",
+			args:        []string{"deploy", "--workspace-name", "test", "--model", "phi-3.5-mini-instruct", "--dry-run"},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, err := runCommand(t, testTimeout, tt.args...)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but command succeeded. Stdout: %s, Stderr: %s", stdout, stderr)
+					return
+				}
+				// For kubectl plugins with SilenceErrors=true, we just check that it exits with non-zero code
+				// The actual error messages are suppressed, which is correct behavior
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v\nStdout: %s\nStderr: %s", err, stdout, stderr)
+					return
+				}
+			}
+
+			t.Logf("✅ %s validation successful", tt.name)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces end-to-end testing infrastructure for the `kubectl-kaito` plugin specifically designed for Azure Kubernetes Service (AKS). The test suite validates plugin functionality in real AKS clusters with real nodes, ensuring production-ready quality and Azure-specific compatibility.
