### PR TITLE
fix: Add support for custom model images in tuning mode

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -55,6 +55,7 @@ These flags can only be used when `--tuning` is **enabled**:
 | ------------------------------ | -------- | ------- | --------------------------------- |
 | `--tuning`                     | bool     | false   | Enable fine-tuning mode           |
 | `--tuning-method string`       | string   | qlora   | Fine-tuning method (qlora, lora)  |
+| `--model-image string`         | string   |         | Custom image for the model preset |
 | `--input-urls strings`         | []string |         | URLs to training data             |
 | `--input-pvc string`           | string   |         | PVC containing training data      |
 | `--output-image string`        | string   |         | Output image for fine-tuned model |
@@ -114,20 +115,22 @@ kubectl kaito deploy \
 ### Fine-tuning Deployment
 
 ```bash
-# Deploy for fine-tuning with QLoRA using URLs
+# Deploy for fine-tuning with QLoRA using URLs and custom model image
 kubectl kaito deploy \
   --workspace-name tune-phi \
   --model phi-3.5-mini-instruct \
   --tuning \
   --tuning-method qlora \
+  --model-image myregistry/phi-base:latest \
   --input-urls "https://example.com/data.parquet" \
   --output-image myregistry/phi-finetuned:latest
 
-# Deploy for fine-tuning with PVC storage
+# Deploy for fine-tuning with PVC storage and custom model image
 kubectl kaito deploy \
   --workspace-name tune-llama \
   --model llama-3.1-8b-instruct \
   --tuning \
+  --model-image myregistry/llama-base:latest \
   --input-pvc training-data \
   --output-pvc model-output
 ```


### PR DESCRIPTION
This PR adds support for specifying a custom model image when using tuning mode. This allows users to provide their own base model images instead of relying on the default ones.

### Changes

- Add `--model-image` flag to specify a custom image for the model preset
- Add unit tests
- Updated `docs/deploy.md` to include new `--model-image` flag in tuning flags section and update the example.

### Example Usage

```bash
# Using a custom model image with URLs
kubectl kaito deploy \
  --workspace-name tune-phi \
  --model falcon-7b \
  --tuning \
 --model-image aimodelsregistrytest.azurecr.io/kaito-falcon-7b:0.0.4
  --tuning-method qlora \
  --input-urls "<URL>" \
  --output-image myregistry/phi-finetuned:latest \
  --output-image-secret <secret>
```