### PR TITLE
ci: Add krew release bot to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tag }}
+      
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.47
+        with:
+          krew_template_file: ./krew/kaito.yaml


### PR DESCRIPTION
Setting up [Krew release automation](https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/) to help skiping manually making updates to the Krew manifests on each new version and send a pull request. It’s a GitHub workflow bot that can run every time you push a new tag. Those PRs are automatically approved.